### PR TITLE
Update client to include model info, update includes

### DIFF
--- a/autogen_watsonx_client/client.py
+++ b/autogen_watsonx_client/client.py
@@ -1,15 +1,15 @@
 from typing import Mapping, Optional, Sequence, Any, Union, AsyncGenerator
 from dataclasses import asdict
 
-from autogen_core.base import CancellationToken
-from autogen_core.components import FunctionCall, Image
-from autogen_ext.models._openai._openai_client import _add_usage
-from autogen_core.components.tools import Tool, ToolSchema
+from autogen_core import CancellationToken
+from autogen_core import FunctionCall, Image
+from autogen_ext.models.openai._openai_client import _add_usage
+from autogen_core.tools import Tool, ToolSchema
 from typing_extensions import Unpack
 
-from autogen_core.components.models import (
+from autogen_core.models import (
     ChatCompletionClient, RequestUsage, LLMMessage, CreateResult, SystemMessage, AssistantMessage, UserMessage,
-    FunctionExecutionResultMessage, ModelCapabilities,
+    FunctionExecutionResultMessage, ModelCapabilities, ModelInfo
 )
 from ibm_watsonx_ai.foundation_models import ModelInference
 
@@ -253,6 +253,15 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
             vision=True,
             function_calling=True,
             json_output=True,
+        )
+
+    @property
+    def model_info(self) -> ModelInfo:
+        return ModelInfo(
+            vision=True,
+            function_calling=True,
+            json_output=True,
+            family="watsonx",
         )
 
     # TODO: implement __get_state__ and __set_state__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "autogen_watsonx_client"
 version = "0.0.4.dev1"
 dependencies = [
-    "autogen-core>=0.4.0.dev9,<0.5", # TODO: remove dev tag after release
-    "autogen-ext>=0.4.0.dev9,<0.5",
+    "autogen-core>=0.4.0.dev13,<0.5", # TODO: remove dev tag after release
+    "autogen-ext>=0.4.0.dev13,<0.5",
     "ibm-watsonx-ai>=1.1.22",
 ]
 requires-python = ">=3.10, <3.13"


### PR DESCRIPTION
I wanted to let you know that we just merged a small change to the `ChatCompletionClient` interface https://github.com/microsoft/autogen/pull/4856

This change changes `ModelCapabilities` to `ModelInfo` and adds a `"family"` key to the dict. I've also updated the includes.

I wasn't able to test the change, but wanted to make it as easy as possible for you to update.