### PR TITLE
Add close method & update pyproject.toml

### DIFF
--- a/autogen_watsonx_client/client.py
+++ b/autogen_watsonx_client/client.py
@@ -346,6 +346,9 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
         # TODO: any watsonx api to support this?
         return 1
 
+    async def close(self) -> None:
+        await self._client._inference._async_http_client.aclose()
+
     @property
     def capabilities(self) -> ModelCapabilities:
         return ModelCapabilities(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autogen_watsonx_client"
-version = "0.0.7.dev1"
+version = "0.0.7.dev2"
 dependencies = [
-    "autogen-core>=0.4.6",
-    "autogen-ext>=0.4.6",
-    "ibm-watsonx-ai>=1.2.6",
+    "autogen-core>=0.4.9.2",
+    "autogen-ext>=0.4.9.2",
+    "ibm-watsonx-ai>=1.3.1",
 ]
 requires-python = ">=3.10, <3.13"
 description = "This is an autogen>=0.4 extension for watsonx client integration."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "autogen_watsonx_client"
 version = "0.0.7.dev2"
 dependencies = [
-    "autogen-core>=0.4.9.2",
-    "autogen-ext>=0.4.9.2",
-    "ibm-watsonx-ai>=1.3.1",
+    "autogen-core>=0.4.6",
+    "autogen-ext>=0.4.6",
+    "ibm-watsonx-ai>=1.2.6",
 ]
 requires-python = ">=3.10, <3.13"
 description = "This is an autogen>=0.4 extension for watsonx client integration."


### PR DESCRIPTION
Small fix for the bug with latest versions. 

The problem visible below - it is impossible to create `WatsonXChatCompletionClient` object:
```
----> 9 wx_client = WatsonXChatCompletionClient(**wx_config)

TypeError: Can't instantiate abstract class WatsonXChatCompletionClient with abstract method close
```
With proposed changes, setup seems to work correctly.
