### PR TITLE
Update client to support token & close method

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @tsinggggg
+*       @tsinggggg @Wojciech-Rebisz

--- a/autogen_watsonx_client/__init__.py
+++ b/autogen_watsonx_client/__init__.py
@@ -1,4 +1,4 @@
 from autogen_watsonx_client.config import WatsonxClientConfiguration
 from autogen_watsonx_client.client import WatsonXChatCompletionClient
 
-__version = "0.0.7.dev1"
+__version = "0.0.7.dev2"

--- a/autogen_watsonx_client/client.py
+++ b/autogen_watsonx_client/client.py
@@ -277,9 +277,9 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
                 chunk_future = asyncio.ensure_future(anext(stream))
                 chunk = await chunk_future
 
-                #  If there are no choices in chunk, exit the loop
+                #  Avoid KeyError, go to next iteration
                 if not chunk.get("choices"):
-                    break  
+                    continue
 
                 choice = chunk["choices"][0]
 

--- a/autogen_watsonx_client/client.py
+++ b/autogen_watsonx_client/client.py
@@ -11,6 +11,7 @@ from autogen_core.models import (
     ChatCompletionClient, RequestUsage, LLMMessage, CreateResult, SystemMessage, AssistantMessage, UserMessage,
     FunctionExecutionResultMessage, ModelCapabilities, ModelInfo
 )
+from ibm_watsonx_ai import Credentials
 from ibm_watsonx_ai.foundation_models import ModelInference
 
 from autogen_watsonx_client.config import WatsonxClientConfiguration
@@ -133,8 +134,10 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
 
         # url
         url = kwargs.pop("url", "https://us-south.ml.cloud.ibm.com")
-        # api key is required
-        api_key = kwargs.pop("api_key")
+        # api key is optional
+        api_key = kwargs.pop("api_key", None)
+        # token if needed
+        token = kwargs.pop("token", None)
         # one of space_id or project_id should be provided
         space_id = kwargs.pop("space_id", None)
         project_id = kwargs.pop("project_id", None)
@@ -146,13 +149,13 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
         # decoding params
         wx_params = dict(kwargs).copy()
 
+        # api_key or token can be used
+        credentials = Credentials(url=url, api_key=api_key, token=token)
+
         # client
         self._client = ModelInference(
             model_id=model_id,
-            credentials={
-                "api_key": api_key,
-                "url": url,
-            },
+            credentials=credentials,
             space_id=space_id,
             project_id=project_id,
             params=wx_params,
@@ -274,6 +277,10 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
                 chunk_future = asyncio.ensure_future(anext(stream))
                 chunk = await chunk_future
 
+                #  If there are no choices in chunk, exit the loop
+                if not chunk.get("choices"):
+                    break  
+
                 choice = chunk["choices"][0]
 
                 # First try to get content (content could be empty string, especially the first delta)
@@ -345,6 +352,9 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
     def remaining_tokens(self, messages: Sequence[LLMMessage], tools: Sequence[Tool | ToolSchema] = []) -> int:
         # TODO: any watsonx api to support this?
         return 1
+
+    async def close(self) -> None:
+        await self._client._inference._async_http_client.aclose()
 
     @property
     def capabilities(self) -> ModelCapabilities:

--- a/autogen_watsonx_client/config.py
+++ b/autogen_watsonx_client/config.py
@@ -26,7 +26,8 @@ class WatsonxCreateArguments(TypedDict, total=False):
 
 class WatsonxClientConfiguration(WatsonxCreateArguments, total=False):
     model_id: str
-    api_key: str
+    api_key: Optional[str]
     url: Optional[str]
     space_id: Optional[str]
     project_id: Optional[str]
+    token: Optional[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autogen_watsonx_client"
-version = "0.0.7.dev1"
+version = "0.0.7.dev2"
 dependencies = [
     "autogen-core>=0.4.6",
     "autogen-ext>=0.4.6",


### PR DESCRIPTION
In this PR:

1. Added implementation of `close()` method
2. Added support for token in `WatsonXChatCompletionClient`
3. Modifications in CODEOWNERS
4. Small fix for KeyError in case there are no "choices" in response