### PR TITLE
fix: extend finish reasons to accept length

### DIFF
--- a/autogen_watsonx_client/__init__.py
+++ b/autogen_watsonx_client/__init__.py
@@ -1,4 +1,4 @@
 from autogen_watsonx_client.config import WatsonxClientConfiguration
 from autogen_watsonx_client.client import WatsonXChatCompletionClient
 
-__version = "0.0.7.dev2"
+__version = "0.0.7"

--- a/autogen_watsonx_client/__init__.py
+++ b/autogen_watsonx_client/__init__.py
@@ -1,4 +1,4 @@
 from autogen_watsonx_client.config import WatsonxClientConfiguration
 from autogen_watsonx_client.client import WatsonXChatCompletionClient
 
-__version = "0.0.7"
+__version = "0.0.8.dev1"

--- a/autogen_watsonx_client/client.py
+++ b/autogen_watsonx_client/client.py
@@ -378,6 +378,9 @@ class WatsonXChatCompletionClient(ChatCompletionClient):
     FINISH_REASONS = {
         "tool_calls": "function_calls",
         "stop": "stop",
+        "length": "length",
+        "content_filter": "content_filter",
+        "unknown": "unknown",
     }
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autogen_watsonx_client"
-version = "0.0.7.dev2"
+version = "0.0.7"
 dependencies = [
     "autogen-core>=0.4.6",
     "autogen-ext>=0.4.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autogen_watsonx_client"
-version = "0.0.8.dev1"
+version = "0.0.8.dev2"
 dependencies = [
     "autogen-core>=0.4.6",
     "autogen-ext>=0.4.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autogen_watsonx_client"
-version = "0.0.7"
+version = "0.0.8.dev1"
 dependencies = [
     "autogen-core>=0.4.6",
     "autogen-ext>=0.4.6",


### PR DESCRIPTION
Small fix for the problem visible below:

![image](https://github.com/user-attachments/assets/835a411a-3aaf-40f7-8726-1fb73cf437ed)

See autogen core documentation for available finish reasons:
https://microsoft.github.io/autogen/stable//reference/python/autogen_core.models.html#autogen_core.models.CreateResult.finish_reason
